### PR TITLE
Update Help Text

### DIFF
--- a/src/plusplus.ts
+++ b/src/plusplus.ts
@@ -359,17 +359,16 @@ async function respondWithHelpGuidance({ message, context, say }) {
     .concat(`\`@${'qrafty'} level me up\` - Level up your account for some additional ${'qrafty'}iness \n`)
     .concat('`how much are <point_type> points worth` - Shows how much <point_type> points are worth\n');
 
-  var furtherInformationMessage =
-    procVars.furtherHelpUrl !== undefined ? `For further help please visit ${procVars.furtherHelpUrl}` : 'Thanks!';
-
   const theMessage = Message({ channel: context.channel, text: 'Help menu for Qrafty' })
     .blocks(
       Blocks.Header().text(`Need help with ${'Qrafty'}?`),
       Blocks.Section().text(`_Commands_:`),
-      Blocks.Divider(),
       Blocks.Section().text(helpMessage),
-      Blocks.Section().text(furtherInformationMessage),
     )
     .asUser();
+  if (procVars.furtherHelpUrl !== undefined) {
+    var furtherInfoMessage = `For further help please visit ${procVars.furtherHelpUrl}`;
+    theMessage.blocks(Blocks.Section().text(furtherInfoMessage));
+  }
   await say({ blocks: theMessage.getBlocks() });
 }


### PR DESCRIPTION
Updates Help Text to display correctly.   I believe the issue was you can't have a .text() with an empty string, which was the case if the more information url was not provided. I moved them into a conditional footer for when it is provided.